### PR TITLE
Revert "Bump flask from 2.2.2 to 2.2.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Jinja2==3.1.2
 Flask_SocketIO==5.3.2
-Flask==2.2.3
+Flask==2.2.2
 PyYAML==6.0


### PR DESCRIPTION
Reverts alivx/revealjs-digital-signage#35